### PR TITLE
Self-nominate "cargo-run-bin" to 2023-08-09

### DIFF
--- a/draft/2023-08-09-this-week-in-rust.md
+++ b/draft/2023-08-09-this-week-in-rust.md
@@ -35,6 +35,8 @@ and just ask the editors to select the category.
 
 ### Project/Tooling Updates
 
+- [cargo-run-bin v1.0.0: Build, cache, and run CLI tools scoped in Cargo.toml rather than installing globally.](https://github.com/dustinblackman/cargo-run-bin)
+
 ### Observations/Thoughts
 
 ### Rust Walkthroughs


### PR DESCRIPTION
## Overview

Self nominating my own tool, [`cargo-run-bin`](https://github.com/dustinblackman/cargo-run-bin). Build, cache, and run CLI tools scoped in `Cargo.toml` rather than installing globally. Stop the version drifts across your team, keep it all in sync within your project!

Installing tooling globally when working in teams or on CI is a silly problem to manage. `cargo-run-bin` builds, caches, and executes CLI tools from their locked down versions in `Cargo.toml`. This acts similarly to [`npm run`](https://docs.npmjs.com/cli/v7/commands/npm-run-script) and [`gomodrun`](https://github.com/dustinblackman/gomodrun), and allows your teams to always be running the same tooling versions.

For command lines that extend cargo such as `cargo-nextest`, run-bin will create and manage cargo aliases to allow using cargo extensions without any changes to your command line scripts! `cargo-run-bin` gets out of your way, and you'll forget you're even using it.
